### PR TITLE
[Feat] 문제풀이 서비스 API 요청 인증 필터 추가 및 API 명세서 출력 사본 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,8 +50,16 @@ dependencies {
     //Validation을 위한 의존성 추가
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation', version: '2.5.2'
 
+    implementation 'javax.xml.bind:jaxb-api:2.3.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 
+    // jwt
+    implementation 'com.google.code.gson:gson:2.9.1'
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
 }
 
 tasks.named('test') {
@@ -94,7 +102,7 @@ asciidoctor { // (7)
 task copyDocument(type: Copy) { // (12)
     dependsOn asciidoctor
     from file("build/docs/asciidoc/")
-    into file("src/main/resources/static/docs")
+    into file("src/main/resources/static/docs/solve")
 }
 
 build { // (13)
@@ -113,7 +121,7 @@ task copyPrivate(type: Copy) {
 bootJar { // (14)
     dependsOn copyDocument
     from ("${asciidoctor.outputDir}") {
-        into 'src/main/resources/static/docs'
+        into 'src/main/resources/static/docs/solve'
     }
     copyPrivate
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -11,7 +11,71 @@
 
 === 문제 등록(Problem Save)
 Request
-// include::{snippets}/problem/save/http-request.adoc[]
+include::{snippets}/problem/saveProblem/http-request.adoc[]
 
 Response
-// include::{snippets}/problem/save/http-response.adoc[]
+include::{snippets}/problem/saveProblem/http-response.adoc[]
+
+=== 문제 수정(Problem Save)
+
+Request
+include::{snippets}/problem/updateProblem/http-request.adoc[]
+
+Response
+include::{snippets}/problem/updateProblem/http-response.adoc[]
+
+=== 문제 수정(Problem Update)
+
+Request
+include::{snippets}/problem/updateProblem/http-request.adoc[]
+
+Response
+include::{snippets}/problem/updateProblem/http-response.adoc[]
+
+=== 문제 삭제(Problem Delete)
+
+Request
+include::{snippets}/problem/deleteProblem/http-request.adoc[]
+
+Response
+include::{snippets}/problem/deleteProblem/http-response.adoc[]
+
+=== 문제 상세 조회(Problem Detail)
+
+Request
+include::{snippets}/problem/detailProblem/http-request.adoc[]
+
+Response
+include::{snippets}/problem/detailProblem/http-response.adoc[]
+
+=== 문제 목록 조회 - 좋아요순(Problem Search - order by like)
+
+Request
+include::{snippets}/problem/likeSearch/http-request.adoc[]
+
+Response
+include::{snippets}/problem/detailProblem/http-response.adoc[]
+
+=== 문제 목록 조회 (Problem Search)
+
+Request
+include::{snippets}/problem/search/http-request.adoc[]
+
+Response
+include::{snippets}/problem/search/http-response.adoc[]
+
+=== 문제 게시글 첨부파일 등록 (Problem Attach apply)
+
+Request
+include::{snippets}/s3/uplooad/http-request.adoc[]
+
+Response
+include::{snippets}/s3/uplooad/http-response.adoc[]
+
+=== 문제 게시글 첨부파일 변경 (Problem Attach update)
+
+Request
+include::{snippets}/s3/update/http-request.adoc[]
+
+Response
+include::{snippets}/s3/update/http-response.adoc[]

--- a/src/main/java/com/developers/solve/config/SecurityConfig.java
+++ b/src/main/java/com/developers/solve/config/SecurityConfig.java
@@ -1,0 +1,93 @@
+package com.developers.solve.config;
+
+import com.developers.solve.filter.RefreshTokenFilter;
+import com.developers.solve.filter.TokenCheckFilter;
+import com.developers.solve.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+
+@Log4j2
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+    private final JwtUtil jwtUtil;
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource(){
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:3000")); // 모든 요청에 설정
+        configuration.setAllowedMethods(Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE", "PATCH")); // 메서드 설정
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type")); // 헤더 설정
+        configuration.setAllowCredentials(true); //인증 설정
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
+        config.setAllowedMethods(Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE", "PATCH"));
+        config.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type"));
+        config.setAllowCredentials(true);
+        config.setMaxAge(Duration.ofHours(1));
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
+    }
+
+    // 웹에서의 시큐리티 적용 설정 - 설정 파일은 security 적용 대상아 아님
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        log.info("------------web configure-------------------");
+        return (web) -> web.ignoring().
+                requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+    }
+
+    private TokenCheckFilter tokenCheckFilter(JwtUtil jwtUtil){
+        return new TokenCheckFilter(jwtUtil);
+    }
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        log.info("-------------------configure-------------------------------");
+        // Acess 토큰 검증 필터 적용하기
+        http.addFilterBefore(tokenCheckFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+        // Refresh 토큰 컴증 필터를 적용하기
+        http.addFilterBefore(new RefreshTokenFilter("/api/auth/refresh", jwtUtil), TokenCheckFilter.class);
+        // API Server는 세션을 사용하지 않기에 세션 사용 중지
+        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        // API Server에서 동작헤야 하기 때문에 CORS 설정 추가
+        http.cors(httpSecurityCorsConfigurer -> {
+            httpSecurityCorsConfigurer.configurationSource(corsConfigurationSource());
+        });
+        http
+                .csrf().disable()
+                .cors()
+                .and()
+                .authorizeHttpRequests()
+                .requestMatchers("/api/authenticate", "/ouath2/**", "/docs/**", "/api/**", "/api/auth/**").permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        return http.build();
+    }
+}

--- a/src/main/java/com/developers/solve/config/WebConfig.java
+++ b/src/main/java/com/developers/solve/config/WebConfig.java
@@ -1,7 +1,6 @@
 package com.developers.solve.config;
 
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -11,12 +10,13 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 
-@Configuration
+//@Configuration
 public class WebConfig  {
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource(){
         CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.asList("*"));
         configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:3000")); // 모든 요청에 설정
         configuration.setAllowedMethods(Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE", "PATCH")); // 메서드 설정
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type")); // 헤더 설정
@@ -38,27 +38,4 @@ public class WebConfig  {
         source.registerCorsConfiguration("/**", config);
         return new CorsFilter(source);
     }
-
-//    @Bean
-//    public CorsFilter corsConfig(){
-//        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-//        CorsConfiguration config = new CorsConfiguration();
-//        config.setAllowCredentials(true);
-//        config.addAllowedOriginPattern("*");
-//        config.addAllowedMethod("*");
-//
-//        source.registerCorsConfiguration("/**",config);
-//        return new CorsFilter(source);
-//    }
-//    @Bean
-//    public CorsConfigurationSource corsConfigurationSource(){
-//        CorsConfiguration configuration = new CorsConfiguration();
-//        configuration.setAllowedOriginPatterns(Arrays.asList("*")); // 모든 요청에 설정
-//        configuration.setAllowedMethods(Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE", "PATCH")); // 메서드 설정
-//        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type")); // 헤더 설정
-//        configuration.setAllowCredentials(true); //인증 설정
-//        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-//        source.registerCorsConfiguration("/**", configuration);
-//        return source;
-//    }
 }

--- a/src/main/java/com/developers/solve/exception/AccessTokenException.java
+++ b/src/main/java/com/developers/solve/exception/AccessTokenException.java
@@ -1,0 +1,54 @@
+package com.developers.solve.exception;
+
+import com.google.gson.Gson;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+
+import java.util.Date;
+import java.util.Map;
+
+
+/**
+ * Access Token 검증 - 예외 처리
+ * AccessToken에 문제가 있는 경우 발생할 사용자 정의 예외 클래스
+ */
+public class AccessTokenException extends RuntimeException {
+    TOKEN_ERROR token_error;
+    public enum TOKEN_ERROR {
+        UNACCEPT(401, "Token is null or too short"),
+        BADTYPE(401, "Token type Bearer"),
+        MALFORM(403, "Malformed Token"),
+        BADSIGN(403, "BadSignatured Token"),
+        EXPIRED(403, "Expired Token");
+        private int stauts;
+        private String msg;
+        TOKEN_ERROR(int stauts, String msg) {
+            this.stauts = stauts;
+            this.msg = msg;
+        }
+        public int getStatus() {
+            return this.stauts;
+        }
+        public Object getMsg() {
+            return this.msg;
+        }
+    }
+
+    public AccessTokenException(TOKEN_ERROR error) {
+        super(error.name());
+        this.token_error = error;
+    }
+
+    // 에러 전송 메서드
+    public void sendResponseError(HttpServletResponse response) {
+        response.setStatus(token_error.getStatus());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        Gson gson = new Gson();
+        String responseStr = gson.toJson(Map.of("msg", token_error.getMsg(), "time", new Date()));
+        try {
+            response.getWriter().println(responseStr);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/developers/solve/exception/RefreshTokenException.java
+++ b/src/main/java/com/developers/solve/exception/RefreshTokenException.java
@@ -1,0 +1,33 @@
+package com.developers.solve.exception;
+
+
+import com.google.gson.Gson;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.Map;
+
+public class RefreshTokenException extends RuntimeException {
+    private ErrorCase errorCase;
+    public enum ErrorCase {
+        NO_ACCESS, NO_REFRESH, OLD_REFRESH
+    }
+    public RefreshTokenException(ErrorCase errorCase) {
+        super(errorCase.name());
+        this.errorCase = errorCase;
+    }
+    public void sendResponseError(HttpServletResponse response) {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        Gson gson = new Gson();
+        String responseStr = gson.toJson(Map.of("msg", errorCase.name(), "time", new Date()));
+        try {
+            response.getWriter().println(responseStr);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/developers/solve/filter/RefreshTokenFilter.java
+++ b/src/main/java/com/developers/solve/filter/RefreshTokenFilter.java
@@ -1,0 +1,144 @@
+package com.developers.solve.filter;
+
+import com.developers.solve.exception.RefreshTokenException;
+import com.developers.solve.util.JwtUtil;
+import com.google.gson.Gson;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+
+@Log4j2
+@RequiredArgsConstructor
+public class RefreshTokenFilter extends OncePerRequestFilter {
+    private final String refreshPath;
+    private final JwtUtil jwtUtil;
+
+    private Map<String,String> parseRequestJSON(HttpServletRequest request) {
+        //JSON 데이터를 분석해서 loginEmail, loginPassword 전달 값을 Map으로 처리
+        try(Reader reader = new InputStreamReader(request.getInputStream())){
+            Gson gson = new Gson();
+            return gson.fromJson(reader, Map.class);
+        }catch(Exception e){
+            log.error(e.getMessage());
+        }
+        return null;
+    }
+
+    // 엑세스 토큰을 검증하는 메서드
+    private void checkAccessToken(String accessToken) throws RefreshTokenException {
+        try{
+            jwtUtil.validateToken(accessToken);
+        } catch (ExpiredJwtException expiredJwtException){
+            log.info("Access Token has expired");
+        } catch(Exception exception){
+            throw new RefreshTokenException(RefreshTokenException.ErrorCase.NO_ACCESS);
+        }
+    }
+
+    // 리프레쉬 토큰을 검증하는 메서드
+    private Map<String, Object> checkRefreshToken(String refreshToken) throws RefreshTokenException{
+        try {
+            Map<String, Object> values = jwtUtil.validateToken(refreshToken);
+            return values;
+        } catch (ExpiredJwtException expiredJwtException){
+            throw new RefreshTokenException(RefreshTokenException.ErrorCase.OLD_REFRESH);
+        } catch (MalformedJwtException malformedJwtException){
+            throw new RefreshTokenException(RefreshTokenException.ErrorCase.NO_REFRESH);
+        } catch (Exception exception){
+            throw new RefreshTokenException(RefreshTokenException.ErrorCase.NO_REFRESH);
+        }
+    }
+
+    // 토큰을 전송하는 메소드
+    private void sendTokens(String accessTokenValue, String refreshTokenValue, HttpServletResponse response) {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        Gson gson = new Gson();
+        String jsonStr = gson.toJson(Map.of("accessToken", accessTokenValue, "refreshToken", refreshTokenValue));
+        try {
+            response.getWriter().println(jsonStr);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        // 클라이언트의 요청 URL
+        String path = request.getRequestURI();
+        // URL이 다르면 다음 필터로 넘기도록 한다.
+        if (!path.equals(refreshPath)) {
+            log.info("[RefreshTokenFilter] skip refresh token filter");
+            // 다음 필터로 진행하고 현재 필터의 동작을 중지시키기 위해서는 반드시 return을 해야 한다.
+            filterChain.doFilter(request, response);
+            return;
+        }
+        log.info("[RefreshTokenFilter] Refresh Token Filter run!");
+
+        //전송된 JSON에서 accessToken과 refreshToken을 얻어온다.
+        Map<String, String> tokens = parseRequestJSON(request);
+        String accessToken = tokens.get("accessToken");
+        String refreshToken = tokens.get("refreshToken");
+        log.info("[RefreshTokenFilter] accessToken: {}", accessToken);
+        log.info("[RefreshTokenFilter] refreshToken: {}", refreshToken);
+
+        try{
+            checkAccessToken(accessToken);
+        }catch(RefreshTokenException refreshTokenException){
+            refreshTokenException.sendResponseError(response);
+            return;
+        }
+
+        Map<String, Object> refreshClaims = null;
+        try {
+            refreshClaims = checkRefreshToken(refreshToken);
+            log.info(refreshClaims);
+        }catch(RefreshTokenException refreshTokenException){
+            refreshTokenException.sendResponseError(response);
+            return;
+        }
+
+        // 토큰을 생성해서 전송하는 로직은 아래와 같다.
+        // Refresh Token의 유효시간이 얼마 남지 않은 경우
+        Integer exp = (Integer) refreshClaims.get("exp");
+        Date expTime = new Date(Instant.ofEpochMilli(exp).toEpochMilli() * 1000);
+        Date current = new Date(System.currentTimeMillis());
+
+        // 만료 시간과 현재 시간의 간격 계산
+        // 만일 3일 미만인 경우에는 Refresh Token도 다시 생성
+        long gapTime = (expTime.getTime() - current.getTime());
+        log.info("[RefreshTokenFilter] 현재시간(current): {}", current);
+        log.info("[RefreshTokenFilter] 만료시간(expTime): {}", expTime);
+        log.info("[RefreshTokenFilter] 남은시간(gap): {}", gapTime );
+
+        // 토큰을 만들 때 사용한 id를 찾아오기
+        String loginEmail = (String)refreshClaims.get("loginEmail");
+        // 무조건 AccessToken을 새로 발급하기
+        String accessTokenValue = jwtUtil.generateToken(Map.of("loginEmail", loginEmail), 1);
+
+        // RefrshToken이 3일도 안남은 경우 재발급하기
+        String refreshTokenValue = tokens.get("refreshToken");
+        if(gapTime < (1000 * 60 * 3 ) ){
+            // if(gapTime < (1000 * 60 * 60 * 24 * 3 ) ){
+            log.info("[RefreshTokenFilter] new Refresh Token required... ");
+            refreshTokenValue = jwtUtil.generateToken(Map.of("loginEmail", loginEmail), 30);
+        }
+        log.info("[RefreshTokenFilter] Refresh Token result");
+        log.info("[RefreshTokenFilter] accessToken: " + accessTokenValue);
+        log.info("[RefreshTokenFilter] refreshToken: " + refreshTokenValue);
+        sendTokens(accessTokenValue, refreshTokenValue, response);
+    }
+}

--- a/src/main/java/com/developers/solve/filter/TokenCheckFilter.java
+++ b/src/main/java/com/developers/solve/filter/TokenCheckFilter.java
@@ -1,0 +1,99 @@
+package com.developers.solve.filter;
+
+import com.developers.solve.exception.AccessTokenException;
+import com.developers.solve.util.JwtUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Log4j2
+@RequiredArgsConstructor
+public class TokenCheckFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+
+    private Map<String, Object> validateAccessToken(HttpServletRequest request) throws AccessTokenException {
+        log.info("request: {}", request.getRequestURI());
+        String headerStr = request.getHeader("Authorization");
+        log.info("[TokenCheckFilter] request header: {}", headerStr);
+
+        // 아래 조건을 만족하지 않는다면 예외 발생
+        if(headerStr == null || headerStr.length() < 8){
+            log.info("[TokenCheckFilter] request header str is null or length < 8");
+            throw new AccessTokenException(AccessTokenException.TOKEN_ERROR.UNACCEPT);
+        }
+        // Bearer 생략, 실제 토큰 가져오기
+        String tokenType = headerStr.substring(0,6);
+        String tokenStr = headerStr.substring(7);
+        // 타입 검사하기
+        if(tokenType.equalsIgnoreCase("Bearer") == false){
+            log.info("[TokenCheckFilter] request token not start str Bearer");
+            throw new AccessTokenException(AccessTokenException.TOKEN_ERROR.BADTYPE);
+        }
+        // 토큰의 유효성 검사하기
+        /**
+         * MalformedJwtException: JWT의 형식이 잘못되어 파싱할 수 없는 경우 발생함. 올바른 형식의 JWT가 아닌 일반 문자열을 파싱하려고 할 때 발생할 수 있음.
+         * SignatureException: JWT의 서명 검증이 실패한 경우 발생함. JWT의 서명은 발행한 서버가 유효한 것으로 증명하기 위해 사용되며, 이 예외는 서명 검증에 실패한 경우 발생함.
+         * ExpiredJwtException: JWT가 만료된 경우 발생함. JWT에는 발행 시간과 만료 시간이 포함되며, 이 예외는 JWT의 만료 시간이 현재 시간보다 이전인 경우 발생함.
+         */
+        try{
+            Map<String, Object> values = jwtUtil.validateToken(tokenStr);
+            return values;
+        }catch(MalformedJwtException malformedJwtException){
+            log.error("[TokenCheckFilter] Token Validation Fail - MalformedJwtException");
+            throw new AccessTokenException(AccessTokenException.TOKEN_ERROR.MALFORM);
+        }catch(SignatureException signatureException){
+            log.error("[TokenCheckFilter] Token Validation Fail - SignatureException");
+            throw new AccessTokenException(AccessTokenException.TOKEN_ERROR.BADSIGN);
+        }catch(ExpiredJwtException expiredJwtException){
+            log.error("[TokenCheckFilter] Token Validation Fail - ExpiredJwtException");
+            throw new AccessTokenException(AccessTokenException.TOKEN_ERROR.EXPIRED);
+        }
+    }
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws IOException, ServletException
+    {
+        // 클라이언트의 URI 확인하기
+        String path = request.getRequestURI();
+        log.info("[TokenCheckFilter] request URI: {}", path);
+        /**
+         * 인증 처리가 필요없다면 TokenCheckFilter 로직을 수횅할 필요가 없음.
+         * 사용자: 로그인, 회원가입
+         * 문제풀이: 전체 문제 목록 조회
+         * 멘토링: 전체 방 목록 조회
+         */
+        if (path.startsWith("/api/problem/list") || path.startsWith("/api/problem/{problemId}/{member}")) {
+            log.info("[TokenCheckFilter] Skip Token Check Filter, path: {}", path);
+            filterChain.doFilter(request, response);
+            return;
+        }
+        // api로 시작하지 않는 요청이라면 다음 필터로 넘긴다.
+        // doFilterInternal는 리턴 타입이 void이기 때문에 리턴을 안해도 될 것 같지만, 리턴을 반드시 해야한다.
+        // return을 만날 때까지 무조건 수행된다.
+        if (!path.startsWith("/api/")) {
+            log.info("[TokenCheckFilter] Skip Token Check Filter");
+            filterChain.doFilter(request, response);
+            return;
+        }
+        log.info("[TokenCheckFilter] Token Check Filter !");
+        try {
+            validateAccessToken(request);
+            // 다음 필터에게 처리를 넘긴다.
+            // AOP, Filter, Interceptor 등으로 넘길 수 있다.
+            filterChain.doFilter(request, response);
+        }catch(AccessTokenException accessTokenException){
+            accessTokenException.sendResponseError(response);
+        }
+    }
+}

--- a/src/main/java/com/developers/solve/util/JwtUtil.java
+++ b/src/main/java/com/developers/solve/util/JwtUtil.java
@@ -1,0 +1,53 @@
+package com.developers.solve.util;
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@Log4j2
+public class JwtUtil {
+    @Value("${com.developers.member.secret}")
+    private String key;
+    public String generateToken(Map<String, Object> valueMap, int minutes) {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("typ", "JWT");
+        headers.put("alg", "HS256");
+        log.info(headers);
+
+        // Payload Part Setting
+        Map<String, Object> payloads = new HashMap<>();
+        payloads.putAll(valueMap);
+        log.info(payloads);
+
+        // 유효 시간(테스트 시에는 짧게 설정)
+        int time = (1) * minutes; //테스트는 분 단위로 나중에 60*24 (일)단위변경
+        // 이후 10분 단위로 조정
+//        int time = (10) * minutes; //테스트는 분단위로 나중에 60*24 (일)단위변경
+
+        return Jwts.builder()
+                .setHeader(headers)
+                .setClaims(payloads)
+                .setIssuedAt(Date.from(ZonedDateTime.now().toInstant()))
+                .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(time).toInstant()))
+                .signWith(SignatureAlgorithm.HS256, key.getBytes())
+                .compact();
+    }
+
+    public Map<String, Object> validateToken(String token) throws JwtException {
+        Map<String, Object> claim = null;
+        claim = Jwts.parser()
+                .setSigningKey(key.getBytes()) // Set Key
+                .parseClaimsJws(token) // 파싱 및 검증, 실패시 에러
+                .getBody();
+        return claim;
+    }
+}

--- a/src/main/resources/static/docs/solve/index.html
+++ b/src/main/resources/static/docs/solve/index.html
@@ -452,8 +452,299 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="paragraph">
 <p>Request</p>
 </div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/problem?_csrf=K0UfW4XGeuOFWRGkOvB4EXx4tYVuWNYNvRBTMoqZ8LS3aMoiTSEpbrb0GNCoaCWXXN1MKB5KmL1fauUgj3FiA7P8ltGHDvoQ HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 186
+Host: localhost:8080
+
+{"type":"CHOICE","writer":"yeop","title":"test","content":"Test111","answer":"2","views":0,"likes":0,"answerCandidate":null,"level":"silver","hashTag":"[Cs, java, good]","pathname":null}</code></pre>
+</div>
+</div>
 <div class="paragraph">
 <p>Response</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 86
+
+{"code":"200 OK","msg":"정상적으로 문제를 생성하였습니다.","data":null}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_문제_수정problem_save"><a class="link" href="#_문제_수정problem_save">문제 수정(Problem Save)</a></h3>
+<div class="paragraph">
+<p>Request</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PATCH /api/problem?_csrf=nrig3ORpf-35OSW-WcYxu2ZbA6UlY1oruiIgMysq3PokyFPf-IqT6d1cT9rUXBaLausFilBsLsdDV2sG2RMUBhIb6ssUrGe- HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 221
+Host: localhost:8080
+
+{"problemId":5,"type":"choice","writer":"yeop","title":"updated title","content":"what is this","answer":"yeop","answerCandidate":["test1","test2","test3"],"hashTag":"[ttag, test]","level":"silver","pathname":"이미지"}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Response</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 58
+
+{"code":"200 OK","msg":"수정이 완료되었습니다."}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_문제_수정problem_update"><a class="link" href="#_문제_수정problem_update">문제 수정(Problem Update)</a></h3>
+<div class="paragraph">
+<p>Request</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PATCH /api/problem?_csrf=nrig3ORpf-35OSW-WcYxu2ZbA6UlY1oruiIgMysq3PokyFPf-IqT6d1cT9rUXBaLausFilBsLsdDV2sG2RMUBhIb6ssUrGe- HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 221
+Host: localhost:8080
+
+{"problemId":5,"type":"choice","writer":"yeop","title":"updated title","content":"what is this","answer":"yeop","answerCandidate":["test1","test2","test3"],"hashTag":"[ttag, test]","level":"silver","pathname":"이미지"}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Response</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 58
+
+{"code":"200 OK","msg":"수정이 완료되었습니다."}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_문제_삭제problem_delete"><a class="link" href="#_문제_삭제problem_delete">문제 삭제(Problem Delete)</a></h3>
+<div class="paragraph">
+<p>Request</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/problem/10?_csrf=Y33fRi_DmOqBqGNd5P1FYal6Kkt4Mar7VR-byqLa06qi6TkzAB-6JBahromsn1Vq3dBxUp4ZB3MZVZnWNi-v_cHtsJqX0FoH HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 2
+Host: localhost:8080
+
+10</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Response</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: text/plain;charset=UTF-8
+Content-Length: 15
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+
+Complete Delete</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_문제_상세_조회problem_detail"><a class="link" href="#_문제_상세_조회problem_detail">문제 상세 조회(Problem Detail)</a></h3>
+<div class="paragraph">
+<p>Request</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/problem/2/lango HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Response</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 422
+
+{"code":"200 OK","msg":"정상적으로 조회 완료하였습니다.","data":{"problemId":2,"type":"CHOICE","writer":"writer","title":"Spring Boot의 장/단점 중 잘못된 것은 무엇일까요?","content":"Spring Boot의 장/단점 중 잘못된 것은 무엇인지 4가지 중에 골라주세요.","answer":"1","level":"bronze","hashTag":"","views":0,"likes":0,"solved":true,"answerCandidate":null,"pathname":null}}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_문제_목록_조회_좋아요순problem_search_order_by_like"><a class="link" href="#_문제_목록_조회_좋아요순problem_search_order_by_like">문제 목록 조회 - 좋아요순(Problem Search - order by like)</a></h3>
+<div class="paragraph">
+<p>Request</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/problem?search=spring HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Response</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 422
+
+{"code":"200 OK","msg":"정상적으로 조회 완료하였습니다.","data":{"problemId":2,"type":"CHOICE","writer":"writer","title":"Spring Boot의 장/단점 중 잘못된 것은 무엇일까요?","content":"Spring Boot의 장/단점 중 잘못된 것은 무엇인지 4가지 중에 골라주세요.","answer":"1","level":"bronze","hashTag":"","views":0,"likes":0,"solved":true,"answerCandidate":null,"pathname":null}}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_문제_목록_조회_problem_search"><a class="link" href="#_문제_목록_조회_problem_search">문제 목록 조회 (Problem Search)</a></h3>
+<div class="paragraph">
+<p>Request</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/problem/list?order=createdTime&amp;writer=John+Doe HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Response</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 59
+
+{"msg":"Success sort","status":"status Code 200","data":[]}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_문제_게시글_첨부파일_등록_problem_attach_apply"><a class="link" href="#_문제_게시글_첨부파일_등록_problem_attach_apply">문제 게시글 첨부파일 등록 (Problem Attach apply)</a></h3>
+<div class="paragraph">
+<p>Request</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/s3/upload?_csrf=1RwlZGPX_RcanKHvlvpoOUoXk1wqlXrK_mfofxVlaauf3Y9Rt3pDAVqxzSQ3rZjcpddcX3wgvj0ZrRnnmlfdTCxcX5KrvOo1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 67
+Host: localhost:8080
+
+{
+  "pathname" : [ "path1", "path2", "path3" ],
+  "problemId" : 1
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Response</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: text/plain;charset=UTF-8
+Content-Length: 29
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+
+Success Updated Attached File</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_문제_게시글_첨부파일_변경_problem_attach_update"><a class="link" href="#_문제_게시글_첨부파일_변경_problem_attach_update">문제 게시글 첨부파일 변경 (Problem Attach update)</a></h3>
+<div class="paragraph">
+<p>Request</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/s3/update?_csrf=SphHIVDBIorY01_-cD_LBt7Nf6lnnNs0rx3QB_-W0xf19jigeK92GDL3QbP1sTnLFRL_YO_0UpBQr-oZlni2Zcnz6y6Wxw-U HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 67
+Host: localhost:8080
+
+{
+  "pathname" : [ "path1", "path2", "path3" ],
+  "problemId" : 1
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Response</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: text/plain;charset=UTF-8
+Content-Length: 29
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+
+Success Updated Attached File</code></pre>
+</div>
 </div>
 </div>
 </div>
@@ -462,7 +753,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-04-18 16:49:47 +0900
+Last updated 2023-04-25 19:03:37 +0900
 </div>
 </div>
 </body>

--- a/src/test/java/com/developers/solve/controller/SolutionControllerTest.java
+++ b/src/test/java/com/developers/solve/controller/SolutionControllerTest.java
@@ -1,0 +1,53 @@
+package com.developers.solve.controller;
+
+import com.developers.solve.solution.controller.SolutionController;
+import com.developers.solve.solution.dto.SolutionRequest;
+import com.developers.solve.solution.service.SolutionService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureRestDocs
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(SolutionController.class)
+@WithMockUser(roles = "USER")
+public class SolutionControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private SolutionService solutionService;
+    ObjectMapper objectMapper = new ObjectMapper();
+    @Test
+    public void solutionTest1() throws Exception {
+        SolutionRequest request = SolutionRequest.builder()
+                .solver("lango")
+                .problemId(43L)
+                .build();
+
+        mockMvc.perform(post("/api/solution")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print())
+                .andDo(document("problem/saveSolution",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## 🤔 Motivation
- 문제풀이 서비스 API 요청 인증 필터 추가 및 API 명세서 출력 사본 추가

<br>

## 💡 Key Changes
- 클라이언트에서 문제풀이 서비스로 API 요청할 때 요청헤더에 담긴 토큰을 검증하고 요청을 허가 및 거절할 수 있도록 인증 필터 로직을 추가했습니다.
- Spring Rest Docs를 통해 API 명세서를 외부에서 확인하기 위한 html 문서를 추가했습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team 

close #46 
close #47 